### PR TITLE
[upgrade] to latest `ansible.suitcase`

### DIFF
--- a/grantsible
+++ b/grantsible
@@ -20,8 +20,6 @@ ensure_ansible () {
             bash -x
     fi
     export PATH="$PWD/ansible-deps-cache/bin:$PATH"
-    export ANSIBLE_ROLES_PATH="$PWD/ansible-deps-cache/roles"
-    export ANSIBLE_COLLECTIONS_PATHS="$PWD/ansible-deps-cache"
 
     . ansible-deps-cache/lib.sh
 }


### PR DESCRIPTION
No need to massage the `ANSIBLE_ROLES_PATH` and `ANSIBLE_COLLECTIONS_PATHS` environment variables anymore; the shim script that the suitcase creates now takes care of that.